### PR TITLE
fixed 推送模板信息回调，通知服务器是否成功推送

### DIFF
--- a/lib/generators/templates/weixin_controller.rb
+++ b/lib/generators/templates/weixin_controller.rb
@@ -138,6 +138,7 @@ WeixinRailsMiddleware::WeixinController.class_eval do
     # </xml>
     # 推送模板信息回调，通知服务器是否成功推送
     def handle_templatesendjobfinish_event
+      Rails.logger.info("回调事件处理")
     end
 
 end

--- a/lib/generators/templates/weixin_controller.rb
+++ b/lib/generators/templates/weixin_controller.rb
@@ -127,4 +127,17 @@ WeixinRailsMiddleware::WeixinController.class_eval do
       Rails.logger.info("回调事件处理")
     end
 
+    # <xml>
+    # <ToUserName><![CDATA[gh_7f083739789a]]></ToUserName>
+    # <FromUserName><![CDATA[oia2TjuEGTNoeX76QEjQNrcURxG8]]></FromUserName>
+    # <CreateTime>1395658920</CreateTime>
+    # <MsgType><![CDATA[event]]></MsgType>
+    # <Event><![CDATA[TEMPLATESENDJOBFINISH]]></Event>
+    # <MsgID>200163836</MsgID>
+    # <Status><![CDATA[success]]></Status>
+    # </xml>
+    # 推送模板信息回调，通知服务器是否成功推送
+    def handle_templatesendjobfinish_event
+    end
+
 end


### PR DESCRIPTION
在推送完模板信息会报错，将默认模板添加这个方法

oMethodError (undefined method `handle_templatesendjobfinish_event' for #<KuiwangController:0x00000109b647e8>):
  app/decorators/controllers/weixin_rails_middleware/weixin_controller_decorator.rb:58:in `response_event_message'
  app/controllers/kuiwang_controller.rb:16:in `reply'