### PR TITLE
兼容 Rails 3

### DIFF
--- a/app/controllers/weixin_rails_middleware/weixin_controller.rb
+++ b/app/controllers/weixin_rails_middleware/weixin_controller.rb
@@ -8,6 +8,11 @@ module WeixinRailsMiddleware
     before_action :set_keyword, only: :reply
 
     def index
+      if Rails::VERSION::MAJOR >= 4
+        render plain: params[:echostr]
+      else
+        render text: params[:echostr]
+      end
     end
 
     def reply
@@ -30,9 +35,8 @@ module WeixinRailsMiddleware
 
       def check_weixin_legality
         check_result = @weixin_adapter.check_weixin_legality
-        valid = check_result.delete(:valid)
-        render check_result if action_name == "index"
-        return valid
+        return if check_result.delete(:valid)
+        render check_result
       end
 
       ## Callback

--- a/lib/weixin_rails_middleware/adapter/weixin_adapter.rb
+++ b/lib/weixin_rails_middleware/adapter/weixin_adapter.rb
@@ -70,7 +70,11 @@ module WeixinRailsMiddleware
       def render_authorize_result(status=401, text=nil, valid=false)
         text = text || error_msg
         Rails.logger.error(text) if status != 200
-        {plain: text, status: status, valid: valid}
+        if Rails::VERSION::MAJOR >= 4
+          {plain: text, status: status, valid: valid}
+        else
+          {text: text, status: status, valid: valid}
+        end
       end
 
       def error_msg


### PR DESCRIPTION
### 问题描述

Rails Version: 3.2.2

WeixinRailsMiddleware Version: 1.3.2

在 Rails 3 下，请求 weixin_server / weixin_reply 路由时，发生模板缺失错误

### 异常栈

```
Started GET "/weixin/gRUxi7molUMFG1AwXFDxZe6DL2BHAKGB?signature=34d7ce4bf1d7cc748d1590188e1c30f40bb432ae&echostr=6508565465004900319&timestamp=1520301017&nonce=1847195940" for 127.0.0.1 at 2018-03-06 09:50:18 +0800
Processing by WechatController#index as */*
  Parameters: {"signature"=>"34d7ce4bf1d7cc748d1590188e1c30f40bb432ae", "echostr"=>"6508565465004900319", "timestamp"=>"1520301017", "nonce"=>"1847195940", "weixin_secret_key"=>"gRUxi7molUMFG1AwXFDxZe6DL2BHAKGB"}
Completed 500 Internal Server Error in 27.0ms

ActionView::MissingTemplate - Missing template wechat/index, weixin_rails_middleware/weixin/index with {:locale=>[:en, :"zh-CN"], :formats=>[:html, :text, :js, :css, :ics, :csv, :png, :jpeg, :gif, :bmp, :tiff, :mpeg, :xml, :rss, :atom, :yaml, :multipart_form, :url_encoded_form, :json, :pdf, :zip, :mobile, :diff, :patch], :handlers=>[:erb, :builder, :coffee, :haml]}. Searched in:
  * "/home/jinhu/Repos/gitee/gitlab/app/views"
  * "/home/jinhu/.rvm/gems/ruby-2.1.9/gems/xray-rails-0.3.1/app/views"
  * "/home/jinhu/.rvm/gems/ruby-2.1.9/bundler/gems/kaminari-4d236ae3736a/app/views"
  * "/home/jinhu/.rvm/gems/ruby-2.1.9/gems/doorkeeper-2.2.1/app/views"
  * "/home/jinhu/.rvm/gems/ruby-2.1.9/gems/devise-2.2.8/app/views"
:
  (gem) actionpack-3.2.22/lib/action_view/template/error.rb:46:in `initialize'
  (gem) actionpack-3.2.22/lib/action_view/path_set.rb:58:in `find'
  (gem) actionpack-3.2.22/lib/action_view/lookup_context.rb:122:in `find'
  (gem) actionpack-3.2.22/lib/action_view/renderer/abstract_renderer.rb:3:in `find_template'
  (gem) actionpack-3.2.22/lib/action_view/renderer/template_renderer.rb:34:in `determine_template'
  (gem) actionpack-3.2.22/lib/action_view/renderer/template_renderer.rb:10:in `render'
  (gem) actionpack-3.2.22/lib/action_view/renderer/renderer.rb:36:in `render_template'
  (gem) actionpack-3.2.22/lib/action_view/renderer/renderer.rb:17:in `render'
  (gem) actionpack-3.2.22/lib/abstract_controller/rendering.rb:110:in `_render_template'
  (gem) actionpack-3.2.22/lib/action_controller/metal/streaming.rb:225:in `_render_template'
  (gem) actionpack-3.2.22/lib/abstract_controller/rendering.rb:103:in `render_to_body'
  (gem) actionpack-3.2.22/lib/action_controller/metal/renderers.rb:28:in `render_to_body'
  (gem) actionpack-3.2.22/lib/action_controller/metal/compatibility.rb:50:in `render_to_body'
  (gem) actionpack-3.2.22/lib/abstract_controller/rendering.rb:88:in `render'
  (gem) actionpack-3.2.22/lib/action_controller/metal/rendering.rb:16:in `render'
  (gem) actionpack-3.2.22/lib/action_controller/metal/instrumentation.rb:40:in `block (2 levels) in render'
  (gem) activesupport-3.2.22/lib/active_support/core_ext/benchmark.rb:5:in `block in ms'
  /home/jinhu/.rvm/rubies/ruby-2.1.9/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
  (gem) activesupport-3.2.22/lib/active_support/core_ext/benchmark.rb:5:in `ms'
  (gem) actionpack-3.2.22/lib/action_controller/metal/instrumentation.rb:40:in `block in render'
  (gem) actionpack-3.2.22/lib/action_controller/metal/instrumentation.rb:83:in `cleanup_view_runtime'
  (gem) activerecord-3.2.22/lib/active_record/railties/controller_runtime.rb:24:in `cleanup_view_runtime'
  (gem) actionpack-3.2.22/lib/action_controller/metal/instrumentation.rb:39:in `render'
  (gem) weixin_rails_middleware-1.3.2/app/controllers/weixin_rails_middleware/weixin_controller.rb:34:in `check_weixin_legality'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:429:in `_run__2952409497157519699__process_action__942689586656842624__callbacks'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:405:in `__run_callback'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:81:in `run_callbacks'
  (gem) actionpack-3.2.22/lib/abstract_controller/callbacks.rb:17:in `process_action'
  (gem) actionpack-3.2.22/lib/action_controller/metal/rescue.rb:29:in `process_action'
  (gem) actionpack-3.2.22/lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
  (gem) activesupport-3.2.22/lib/active_support/notifications.rb:123:in `block in instrument'
  (gem) activesupport-3.2.22/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  (gem) activesupport-3.2.22/lib/active_support/notifications.rb:123:in `instrument'
  (gem) actionpack-3.2.22/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
  (gem) actionpack-3.2.22/lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
  (gem) activerecord-3.2.22/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  (gem) actionpack-3.2.22/lib/abstract_controller/base.rb:121:in `process'
  (gem) actionpack-3.2.22/lib/abstract_controller/rendering.rb:45:in `process'
  (gem) actionpack-3.2.22/lib/action_controller/metal.rb:203:in `dispatch'
  (gem) actionpack-3.2.22/lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
  (gem) actionpack-3.2.22/lib/action_controller/metal.rb:246:in `block in action'
  (gem) actionpack-3.2.22/lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
  (gem) actionpack-3.2.22/lib/action_dispatch/routing/route_set.rb:36:in `call'
  (gem) journey-1.0.4/lib/journey/router.rb:68:in `block in call'
  (gem) journey-1.0.4/lib/journey/router.rb:56:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/routing/route_set.rb:608:in `call'
  (gem) xray-rails-0.3.1/lib/xray/middleware.rb:38:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  config/initializers/devise.rb:17:in `call'
  (gem) exception_notification-4.0.0/lib/exception_notification/rack.rb:28:in `call'
  (gem) http_accept_language-2.0.5/lib/http_accept_language/middleware.rb:14:in `call'
  (gem) rack-cors-0.4.0/lib/rack/cors.rb:80:in `call'
  (gem) warden-1.2.3/lib/warden/manager.rb:35:in `block in call'
  (gem) warden-1.2.3/lib/warden/manager.rb:34:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
  (gem) rack-1.4.7/lib/rack/etag.rb:23:in `call'
  (gem) rack-1.4.7/lib/rack/conditionalget.rb:25:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/head.rb:14:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/params_parser.rb:21:in `call'
  app/middleware/catch_json_parse_errors.rb:8:in `call'
  config/initializers/rails4_to_rails3_downgradability.rb:14:in `call'
  (gem) rack-1.4.7/lib/rack/session/abstract/id.rb:210:in `context'
  (gem) rack-1.4.7/lib/rack/session/abstract/id.rb:205:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/cookies.rb:341:in `call'
  (gem) activerecord-3.2.22/lib/active_record/query_cache.rb:64:in `call'
  (gem) activerecord-3.2.22/lib/active_record/connection_adapters/abstract/connection_pool.rb:479:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:405:in `_run__998290489803278211__call__4486599693378775495__callbacks'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:405:in `__run_callback'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
  (gem) activesupport-3.2.22/lib/active_support/callbacks.rb:81:in `run_callbacks'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  (gem) rails-dev-tweaks-0.6.1/lib/rails_dev_tweaks/granular_autoload/middleware.rb:34:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
  (gem) better_errors-0.8.0/lib/better_errors/middleware.rb:84:in `protected_app_call'
  (gem) better_errors-0.8.0/lib/better_errors/middleware.rb:79:in `better_errors_call'
  (gem) better_errors-0.8.0/lib/better_errors/middleware.rb:56:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
  (gem) railties-3.2.22/lib/rails/rack/logger.rb:32:in `call_app'
  (gem) railties-3.2.22/lib/rails/rack/logger.rb:16:in `block in call'
  (gem) activesupport-3.2.22/lib/active_support/tagged_logging.rb:22:in `tagged'
  (gem) railties-3.2.22/lib/rails/rack/logger.rb:16:in `call'
  (gem) quiet_assets-1.0.2/lib/quiet_assets.rb:18:in `call_with_quiet_assets'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/request_id.rb:22:in `call'
  (gem) rack-1.4.7/lib/rack/methodoverride.rb:21:in `call'
  (gem) rack-1.4.7/lib/rack/runtime.rb:17:in `call'
  (gem) rack-1.4.7/lib/rack/lock.rb:15:in `call'
  (gem) actionpack-3.2.22/lib/action_dispatch/middleware/static.rb:83:in `call'
  (gem) rack-utf8_sanitizer-1.3.0/lib/rack/utf8_sanitizer.rb:15:in `call'
  (gem) railties-3.2.22/lib/rails/engine.rb:484:in `call'
  (gem) railties-3.2.22/lib/rails/application.rb:231:in `call'
  (gem) railties-3.2.22/lib/rails/railtie/configurable.rb:30:in `method_missing'
  (gem) rack-1.4.7/lib/rack/builder.rb:134:in `call'
  (gem) rack-1.4.7/lib/rack/urlmap.rb:64:in `block in call'
  (gem) rack-1.4.7/lib/rack/urlmap.rb:49:in `call'
  lib/demote.rb:30:in `call'
  (gem) rack-1.4.7/lib/rack/content_length.rb:14:in `call'
  (gem) railties-3.2.22/lib/rails/rack/log_tailer.rb:17:in `call'
  (gem) thin-1.5.1/lib/thin/connection.rb:81:in `block in pre_process'
  (gem) thin-1.5.1/lib/thin/connection.rb:79:in `pre_process'
  (gem) thin-1.5.1/lib/thin/connection.rb:54:in `process'
  (gem) thin-1.5.1/lib/thin/connection.rb:39:in `receive_data'
  (gem) eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
  (gem) thin-1.5.1/lib/thin/backends/base.rb:63:in `start'
  (gem) thin-1.5.1/lib/thin/server.rb:159:in `start'
  (gem) rack-1.4.7/lib/rack/handler/thin.rb:13:in `run'
  (gem) rack-1.4.7/lib/rack/server.rb:268:in `start'
  (gem) railties-3.2.22/lib/rails/commands/server.rb:70:in `start'
  (gem) railties-3.2.22/lib/rails/commands.rb:55:in `block in <top (required)>'
  (gem) railties-3.2.22/lib/rails/commands.rb:50:in `<top (required)>'
  script/rails:6:in `<main>'
```

### 原因

Rails 3 不支持 `render :plain`， `WeixinController#check_weixin_legality` 没有正常返回请求，代码执行到 `WeixinController#index`

### 修改描述

对 Rails 3 进行兼容，使用 `render :text` 代替 `render :plain`
